### PR TITLE
Make earnings smarter

### DIFF
--- a/api/insightexplorer.js
+++ b/api/insightexplorer.js
@@ -42,3 +42,23 @@ module.exports.status = () => {
     })
 }
 
+module.exports.difficulty = () => {
+    let key = 'insightexplorer-difficulty'
+    let data = cache.get(key)
+
+    if (undefined !== data) {
+        return Promise.resolve(data)
+    }
+
+    return request({
+        uri: 'https://explorer.btcz.rocks/api/chart/difficulty',
+        json: true,
+    }).then(body => {
+        const difficulties = body.data.json.difficulty
+        const average = difficulties.reduce((p, c) => p + c, 0) / difficulties.length
+        // console.warn(difficulties, average)
+
+        cache.set(key, average)
+        return average
+    })
+}

--- a/commands/earnings.js
+++ b/commands/earnings.js
@@ -1,9 +1,8 @@
 const format = require('../format')
 const coinmarketcap = require('../api/coinmarketcap')
-const btczexplorer = require('../api/btczexplorer')
+const insightexplorer = require('../api/insightexplorer')
 
 const blockSize = 12500
-const blockTime = 150
 
 const earnings = (reply, message) => {
     const hashes = parseInt(message.match[1])
@@ -13,19 +12,17 @@ const earnings = (reply, message) => {
         BTCEarnings = 0,
         USDEarnings = 0
 
-    const callback = () => {
-        reply(
-            message,
-            `${hours} Hour Profitability for *${format.hashrate(hashes)}*:\n` +
-                `- BTCZ: *${format.coins(BTCZEarnings)}*\n` +
-                `- BTC: *${format.coins(BTCEarnings)}*\n` +
-                `- USD: *${format.usd(USDEarnings)}*\n` +
-                `Not accurate? Let @equipool.1ds.us know!`
-        )
-    }
+    const callback = () => reply(
+        message,
+        `${hours} Hour Profitability for *${format.hashrate(hashes)}* (based on the last 8 hrs of difficulty):\n` +
+            `- BTCZ: *${format.coins(BTCZEarnings)}*\n` +
+            `- BTC: *${format.coins(BTCEarnings)}*\n` +
+            `- USD: *${format.usd(USDEarnings)}*\n` +
+            `Not accurate? Let @equipool.1ds.us know!`
+    )
 
-    btczexplorer.netowrkHashrate().then(body => {
-        BTCZEarnings = 1 / ((body / hashes * blockTime) / (hours * 60 * 60)) * blockSize
+    insightexplorer.difficulty().then(difficulty => {
+        BTCZEarnings = ((hashes * blockSize) / (difficulty * 8192)) * (hours * 60 * 60)
 
         coinmarketcap.BTCZTicker().then(body => {
             USDEarnings = BTCZEarnings * body.price_usd
@@ -36,8 +33,24 @@ const earnings = (reply, message) => {
     })
 }
 
-module.exports.init = controller => controller.hears(
-    ['!earnings (.*) (.*)', '!earnings (.*)'],
-    'ambient,bot_message,direct_message,direct_mention,mention',
-    (bot, message) => earnings(bot.reply, message)
-)
+module.exports.init = (controller, general) => {
+    controller.hears(
+        ['!earnings (.*) (.*)', '!earnings (.*)'],
+        'bot_message',
+        (bot, message) => message.channel == general
+            ? bot.reply(message, 'Please use #bot-chat for this command. (telegram: https://t.me/joinchat/GIIFnhKijb9hWUskgwpxoA)')
+            : earnings(bot.reply, message)
+    )
+
+    controller.hears(
+        ['!earnings (.*) (.*)', '!earnings (.*)'],
+        'ambient,mention',
+        (bot, message) => earnings(bot.whisper, message)
+    )
+
+    controller.hears(
+        ['!earnings (.*) (.*)', '!earnings (.*)'],
+        'direct_message,direct_mention',
+        (bot, message) => earnings(bot.reply, message)
+    )
+}


### PR DESCRIPTION
This commit changes the way earnings are calculated. Initially we calculated
based on the current net hashrate. Now, earnings utilizes the difficulty over
the last eight hours for a somewhat more stable calculation.

I wanted to do 24 hours but couldn't quickly figure out how to get that out of
the insight api.