### PR TITLE
Lessen spam in #general

### DIFF
--- a/commands/stats.js
+++ b/commands/stats.js
@@ -16,7 +16,7 @@ const stats = (reply, message) => {
     coinmarketcap.BTCZTicker().then(ticker => {
         stats.push(...[
             `Price: *${format.coins(ticker.price_btc)} BTC (${format.usd(ticker.price_usd)})*`,
-            `25hr Vol (USD): *${format.usd(ticker['24h_volume_usd'])}*`,
+            `24hr Vol (USD): *${format.usd(ticker['24h_volume_usd'])}*`,
             `Market Cap: *${format.usd(ticker.market_cap_usd)}*`,
             `Supply: *${format.integer(ticker.total_supply)} BTCZ*`,
         ])
@@ -48,9 +48,25 @@ const stats = (reply, message) => {
     })
 }
 
-module.exports.init = controller => controller.hears(
-    ['!stats'],
-    'ambient,bot_message,direct_message,direct_mention,mention',
-    (bot, message) => stats(bot.reply, message)
-)
+module.exports.init = (controller, general) => {
+    controller.hears(
+        ['!stats'],
+        'bot_message',
+        (bot, message) => message.channel == general
+            ? bot.reply(message, 'Please use #bot-chat for this command. (telegram: https://t.me/joinchat/GIIFnhKijb9hWUskgwpxoA)')
+            : stats(bot.reply, message)
+    )
+
+    controller.hears(
+        ['!stats'],
+        'ambient,mention',
+        (bot, message) => stats(bot.whisper, message)
+    )
+
+    controller.hears(
+        ['!stats'],
+        'direct_message,direct_mention',
+        (bot, message) => stats(bot.reply, message)
+    )
+}
 

--- a/commands/value.js
+++ b/commands/value.js
@@ -24,8 +24,24 @@ const value = (reply, message) => {
     })
 }
 
-module.exports.init = controller => controller.hears(
-    ['!value (.*)'],
-    'ambient,bot_message,direct_message,direct_mention,mention',
-    (bot, message) => value(bot.reply, message)
-)
+module.exports.init = (controller, general) => {
+    controller.hears(
+        ['!value (.*)'],
+        'bot_message',
+        (bot, message) => message.channel == general
+            ? bot.reply(message, 'Please use #bot-chat for this command. (telegram: https://t.me/joinchat/GIIFnhKijb9hWUskgwpxoA)')
+            : value(bot.reply, message)
+    )
+
+    controller.hears(
+        ['!value (.*)'],
+        'ambient,mention',
+        (bot, message) => value(bot.whisper, message)
+    )
+
+    controller.hears(
+        ['!value (.*)'],
+        'direct_message,direct_mention',
+        (bot, message) => value(bot.reply, message)
+    )
+}

--- a/commands/wallet.js
+++ b/commands/wallet.js
@@ -37,8 +37,24 @@ const wallet = (reply, message) => {
     })
 }
 
-module.exports.init = controller => controller.hears(
-    ['!wallet (.*)'],
-    'ambient,bot_message,direct_message,direct_mention,mention',
-    (bot, message) => wallet(bot.reply, message)
-)
+module.exports.init = (controller, general) => {
+    controller.hears(
+        ['!wallet (.*)'],
+        'bot_message',
+        (bot, message) => message.channel == general
+            ? bot.reply(message, 'Please use #bot-chat for this command. (telegram: https://t.me/joinchat/GIIFnhKijb9hWUskgwpxoA)')
+            : wallet(bot.reply, message)
+    )
+
+    controller.hears(
+        ['!wallet (.*)'],
+        'ambient,mention',
+        (bot, message) => wallet(bot.whisper, message)
+    )
+
+    controller.hears(
+        ['!wallet (.*)'],
+        'direct_message,direct_mention',
+        (bot, message) => wallet(bot.reply, message)
+    )
+}

--- a/index.js
+++ b/index.js
@@ -51,6 +51,8 @@ This bot demonstrates many of the core features of Botkit:
     -> http://howdy.ai/botkit
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 
+const general = 'C77B7UY80'
+
 if (!process.env.token) {
     console.log('Error: Specify token in environment')
     process.exit(1)
@@ -62,20 +64,12 @@ const format = require('./format')
 var controller = Botkit.slackbot({
     debug: true,
     json_file_store: './db',
+    retry: Infinity,
 })
 
 var bot = controller.spawn({
     token: process.env.token
 }).startRTM()
-
-/*********
- * Chatter
- *********/
-const random = require('./commands/random')
-const support = require('./commands/support')
-
-random.init(controller)
-support.init(controller)
 
 /**********
  * Commands
@@ -85,10 +79,19 @@ const earningsCommand = require('./commands/earnings')
 const valueCommand = require('./commands/value')
 const walletCommand = require('./commands/wallet')
 
-statsCommand.init(controller)
-earningsCommand.init(controller)
-valueCommand.init(controller)
-walletCommand.init(controller)
+/*********
+ * Chatter
+ *********/
+const random = require('./commands/random')
+const support = require('./commands/support')
 const jokeCommand = require('./commands/joke')
+
+support.init(controller)
 jokeCommand.init(controller)
+random.init(controller)
+
+statsCommand.init(controller, general)
+earningsCommand.init(controller, general)
+valueCommand.init(controller, general)
+walletCommand.init(controller, general)
 jokeCommand.init(controller)


### PR DESCRIPTION
This commit checks to see if the message is in general.  The logic is:
- If the message is a bot message, it's the relay bot -- discord or telegram.
  - If the channel is #general, tell the user to go to #bot-chat (for some of
    the messages. support messages are OK in #general, IMHO).
  - If the channel isn't #general divulge the information.
- If the message is an ambient or mention, the user is on slack. Whisper the
  message to them (only visible to them).
- If the message is a direct message or direct mention, they're on slack and
  probably in a DM with the bot. Go ahead and just reply.